### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/rdf/base.go
+++ b/rdf/base.go
@@ -44,7 +44,7 @@ type pair struct {
 	key, val string
 }
 
-// Checks if `fmt` is one of the raptor supported formats (has the value of one
+// FormatOk checks if `fmt` is one of the raptor supported formats (has the value of one
 // of the Fmt_* constants). The special "rdf" value is considered invalid by
 // this function.
 func FormatOk(fmt string) bool {

--- a/rdf/writer.go
+++ b/rdf/writer.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// Writes the input to the specified RDF format. Does not parse the RDF file into a
+// WriteRdf writes the input to the specified RDF format. Does not parse the RDF file into a
 // spdx.Document struct and only converts between RDF formats using goraptor.
 func WriteRdf(input *os.File, output *os.File, formatIn, formatOut string) error {
 	if formatIn == "rdf" {
@@ -34,7 +34,7 @@ func WriteRdf(input *os.File, output *os.File, formatIn, formatOut string) error
 	return serializer.AddN(statements)
 }
 
-// Writes a SPDX Document to rdf/xml abbreviated format.
+// Write writes a SPDX Document to rdf/xml abbreviated format.
 func Write(output *os.File, doc *spdx.Document) error {
 	f := NewFormatter(output, Fmt_rdfxmlAbbrev)
 	_, err := f.Document(doc)
@@ -42,7 +42,7 @@ func Write(output *os.File, doc *spdx.Document) error {
 	return err
 }
 
-// Writes a SPDX Document to raptor format. format must be one of the format
+// WriteFormat writes a SPDX Document to raptor format. format must be one of the format
 // constants (Fmt_*)
 func WriteFormat(output *os.File, doc *spdx.Document, format string) error {
 	if format == "rdf" {
@@ -127,7 +127,7 @@ func (f *Formatter) addLiteral(to goraptor.Term, key, value string) error {
 	return f.add(to, prefix(key), &goraptor.Literal{Value: value})
 }
 
-// Write a document.
+// Document writes a document.
 func (f *Formatter) Document(doc *spdx.Document) (docId goraptor.Term, err error) {
 	if doc == nil {
 		return nil, errors.New("Cannot print nil document.")
@@ -180,7 +180,7 @@ func (f *Formatter) Document(doc *spdx.Document) (docId goraptor.Term, err error
 	return docId, nil
 }
 
-// Write creation info.
+// CreationInfo writes creation info.
 func (f *Formatter) CreationInfo(cr *spdx.CreationInfo) (id goraptor.Term, err error) {
 	id = f.newId("cri")
 
@@ -207,7 +207,7 @@ func (f *Formatter) CreationInfo(cr *spdx.CreationInfo) (id goraptor.Term, err e
 	return id, nil
 }
 
-// Write a slice of reviews.
+// Reviews writes a slice of reviews.
 func (f *Formatter) Reviews(parent goraptor.Term, element string, rs []*spdx.Review) error {
 	if len(rs) == 0 {
 		return nil
@@ -227,7 +227,7 @@ func (f *Formatter) Reviews(parent goraptor.Term, element string, rs []*spdx.Rev
 	return nil
 }
 
-// Write a review.
+// Review writes a review.
 func (f *Formatter) Review(r *spdx.Review) (id goraptor.Term, err error) {
 	id = f.newId("rev")
 
@@ -244,7 +244,7 @@ func (f *Formatter) Review(r *spdx.Review) (id goraptor.Term, err error) {
 	return id, err
 }
 
-// Write a slice of packages.
+// Packages writes a slice of packages.
 func (f *Formatter) Packages(parent goraptor.Term, element string, pkgs []*spdx.Package) error {
 	if len(pkgs) == 0 {
 		return nil
@@ -261,7 +261,7 @@ func (f *Formatter) Packages(parent goraptor.Term, element string, pkgs []*spdx.
 	return nil
 }
 
-// Write a package.
+// Package writes a package.
 func (f *Formatter) Package(pkg *spdx.Package) (id goraptor.Term, err error) {
 	id = f.newId("pkg")
 
@@ -331,7 +331,7 @@ func (f *Formatter) Package(pkg *spdx.Package) (id goraptor.Term, err error) {
 	return
 }
 
-// Write a VerificationCode
+// VerificationCode writes a VerificationCode
 func (f *Formatter) VerificationCode(vc *spdx.VerificationCode) (id goraptor.Term, err error) {
 	id = f.newId("vc")
 
@@ -354,7 +354,7 @@ func (f *Formatter) VerificationCode(vc *spdx.VerificationCode) (id goraptor.Ter
 	return id, nil
 }
 
-// Write a Checksum
+// Checksum writes a Checksum
 func (f *Formatter) Checksum(cksum *spdx.Checksum) (id goraptor.Term, err error) {
 	id = f.newId("cksum")
 
@@ -377,7 +377,7 @@ func (f *Formatter) Checksum(cksum *spdx.Checksum) (id goraptor.Term, err error)
 	return id, err
 }
 
-// Write a slice of AnyLicence
+// Licences writes a slice of AnyLicence
 func (f *Formatter) Licences(parent goraptor.Term, element string, lics []spdx.AnyLicence) error {
 	if len(lics) == 0 {
 		return nil
@@ -397,7 +397,7 @@ func (f *Formatter) Licences(parent goraptor.Term, element string, lics []spdx.A
 	return nil
 }
 
-// Write AnyLicence
+// Licence writes AnyLicence
 func (f *Formatter) Licence(licence spdx.AnyLicence) (id goraptor.Term, err error) {
 	switch lic := licence.(type) {
 	case spdx.Licence:
@@ -442,7 +442,7 @@ func (f *Formatter) Licence(licence spdx.AnyLicence) (id goraptor.Term, err erro
 	return nil, errors.New("Licence type not processed. Please report this error along with the SPDX file you were processing.")
 }
 
-// Write a slice of ExtractedLicence
+// ExtrLicInfos writes a slice of ExtractedLicence
 func (f *Formatter) ExtrLicInfos(parent goraptor.Term, element string, lics []*spdx.ExtractedLicence) error {
 	if len(lics) == 0 {
 		return nil
@@ -459,7 +459,7 @@ func (f *Formatter) ExtrLicInfos(parent goraptor.Term, element string, lics []*s
 	return nil
 }
 
-// Write an ExtractedLicence
+// ExtrLicInfo writes an ExtractedLicence
 func (f *Formatter) ExtrLicInfo(lic *spdx.ExtractedLicence) (id goraptor.Term, err error) {
 	id = blank(lic.LicenceId())
 	if lic.LicenceId() == "" {
@@ -495,7 +495,7 @@ func (f *Formatter) ExtrLicInfo(lic *spdx.ExtractedLicence) (id goraptor.Term, e
 	return
 }
 
-// Write a slice of files.
+// Files writes a slice of files.
 func (f *Formatter) Files(parent goraptor.Term, element string, files []*spdx.File) error {
 	if len(files) == 0 {
 		return nil
@@ -515,7 +515,7 @@ func (f *Formatter) Files(parent goraptor.Term, element string, files []*spdx.Fi
 	return nil
 }
 
-// Write a file.
+// File writes a file.
 func (f *Formatter) File(file *spdx.File) (id goraptor.Term, err error) {
 	id, ok := f.fileIds[file.Name.Val]
 	if ok {

--- a/spdx/base.go
+++ b/spdx/base.go
@@ -76,19 +76,19 @@ type ValueCreator struct {
 	*Meta
 }
 
-// Get the original value of this ValueCreator
+// V gets the original value of this ValueCreator
 func (c ValueCreator) V() string { return c.val }
 
-// Get the metadata associated with this ValueCreator
+// M gets the metadata associated with this ValueCreator
 func (c ValueCreator) M() *Meta { return c.Meta }
 
-// Get the `what` part from the format `what: name (email)`.
+// What gets the `what` part from the format `what: name (email)`.
 func (c ValueCreator) What() string { return c.what }
 
-// Get the `name` part from the format `what: name (email)`
+// Name gets the `name` part from the format `what: name (email)`
 func (c ValueCreator) Name() string { return c.name }
 
-// Get the `email` part from the format `what: name (email)`
+// Email gets the `email` part from the format `what: name (email)`
 func (c ValueCreator) Email() string { return c.email }
 
 // Set the value of this ValueCreator. It parses the format `what: name (email)`
@@ -119,13 +119,13 @@ type ValueDate struct {
 	*Meta
 }
 
-// Get the original value of this ValueDate.
+// V gets the original value of this ValueDate.
 func (d ValueDate) V() string { return d.val }
 
-// Get the metadata of this ValueDate.
+// M gets the metadata of this ValueDate.
 func (d ValueDate) M() *Meta { return d.Meta }
 
-// Get the *time.Time pointer parsed form the value.
+// Time gets the *time.Time pointer parsed form the value.
 func (d ValueDate) Time() *time.Time { return d.time }
 
 // Set the value of this ValueDate and parse the date format.
@@ -188,7 +188,7 @@ type ParseError struct {
 	*Meta
 }
 
-// Return the error message.
+// Error returns the error message.
 func (e *ParseError) Error() string {
 	return e.msg
 }

--- a/spdx/document.go
+++ b/spdx/document.go
@@ -18,10 +18,10 @@ type Document struct {
 	*Meta                                 // Document metadata
 }
 
-// Return the document metadata.
+// M returns the document metadata.
 func (doc *Document) M() *Meta { return doc.Meta }
 
-// Checks if this document is equal to `other`. Ignores metadata. Slices
+// Equal checks if this document is equal to `other`. Ignores metadata. Slices
 // elements (ExtractedLicences, Packages, Files and Reviews) must appear
 // in the same order for this method to return true.
 func (doc *Document) Equal(other *Document) bool {
@@ -77,10 +77,10 @@ type CreationInfo struct {
 	*Meta                             // Creation Info meta
 }
 
-// Returns the creation info metadata.
+// M returns the creation info metadata.
 func (ci *CreationInfo) M() *Meta { return ci.Meta }
 
-// Checks if this CreationInfo is equal to `other`. Ignores metadata.
+// Equal checks if this CreationInfo is equal to `other`. Ignores metadata.
 func (ci *CreationInfo) Equal(other *CreationInfo) bool {
 	if ci == other {
 		return true

--- a/spdx/file.go
+++ b/spdx/file.go
@@ -17,10 +17,10 @@ type File struct {
 	*Meta                           // File metadata.
 }
 
-// Returns the File metadata.
+// M returns the File metadata.
 func (f *File) M() *Meta { return f.Meta }
 
-// Checks if this file is equal to `other`. Ignores metadata. Elements
+// Equal checks if this file is equal to `other`. Ignores metadata. Elements
 // in slices file.Contributor, file.Dependency, file.ArtifactOf and
 // file.LicenceInfoInFile must be in the same order for this method to
 // return true.
@@ -72,10 +72,10 @@ type ArtifactOf struct {
 	*Meta               // Artifact metadata.
 }
 
-// Returns the artifact metadata.
+// M returns the artifact metadata.
 func (artif *ArtifactOf) M() *Meta { return artif.Meta }
 
-// Checks if this ArtifactOf is equal to `o`. Ignores metadata.
+// Equal checks if this ArtifactOf is equal to `o`. Ignores metadata.
 func (a *ArtifactOf) Equal(o *ArtifactOf) bool {
 	return a == o || (a != nil && o != nil &&
 		a.ProjectUri.Val == o.ProjectUri.Val &&

--- a/spdx/licence_list.go
+++ b/spdx/licence_list.go
@@ -41,7 +41,7 @@ func InitLicenceList() error {
 	return scanner.Err()
 }
 
-// Checks whether the licence ID `lic` is in the SPDX Licence List.
+// CheckLicence checks whether the licence ID `lic` is in the SPDX Licence List.
 // Calls InitLicenceList() if has not been called before and, if it returns an
 // error, it panics with that error.
 func CheckLicence(lic string) bool {

--- a/spdx/licences.go
+++ b/spdx/licences.go
@@ -13,19 +13,19 @@ type AnyLicence interface {
 // one of the NONE or NOASSERTION constants.
 type Licence struct{ ValueStr }
 
-// Get the licence ID.
+// LicenceId gets the licence ID.
 func (l Licence) LicenceId() string { return l.V() }
 
-// Compare two licences ignoring their metadata.
+// Equal compares two licences ignoring their metadata.
 func (l Licence) Equal(b Licence) bool { return l.ValueStr.Equal(b.ValueStr) }
 
-// Returns whether the licence is a reference or a is supposed to be in the SPDX Licence List.
+// IsReference returns whether the licence is a reference or a is supposed to be in the SPDX Licence List.
 // Does not check if the licence actually is in the licence list (use InList() for that).
 func (l Licence) IsReference() bool {
 	return isLicIdRef(l.V())
 }
 
-// Checks whether the licence is in the SPDX Licence List.
+// InList checks whether the licence is in the SPDX Licence List.
 // It always looks up the SPDX Licence List index.
 func (l Licence) InList() bool {
 	return CheckLicence(l.V())
@@ -46,12 +46,12 @@ type ExtractedLicence struct {
 	*Meta
 }
 
-// Returns the licence ID.
+// LicenceId returns the licence ID.
 func (l *ExtractedLicence) LicenceId() string { return l.Id.V() }
 func (l *ExtractedLicence) V() string         { return l.LicenceId() }
 func (l *ExtractedLicence) M() *Meta          { return l.Meta }
 
-// Checks if this ExtractedLicence is equal to `other`. Ignores metadata.
+// Equal checks if this ExtractedLicence is equal to `other`. Ignores metadata.
 // Slice elements must be in the same order for this function to return true.
 func (l *ExtractedLicence) Equal(other *ExtractedLicence) bool {
 	if l == other {
@@ -140,7 +140,7 @@ func isLicIdRef(id string) bool {
 	return strings.HasPrefix(strings.ToLower(id), "licenseref")
 }
 
-// Compares two licences. Returns `true` if `a` and `b` are the same,
+// SameLicence compares two licences. Returns `true` if `a` and `b` are the same,
 // returns `false` otherwise. In case of licence sets, it recursively
 // applies this function on each element. The licences in sets must be
 // in the same order for this function to return true. Ignores metadata.

--- a/spdx/package.go
+++ b/spdx/package.go
@@ -23,10 +23,10 @@ type Package struct {
 	*Meta                                  // Package metadata.
 }
 
-// Returns the package metadata.
+// M returns the package metadata.
 func (pkg *Package) M() *Meta { return pkg.Meta }
 
-// Checks if this package is equal to `other`. Ignores metadata. Elements
+// Equal checks if this package is equal to `other`. Ignores metadata. Elements
 // in slices pkg.Files and pkg.LicenceInfoFromFiles must be in the same
 // order for this method to return true.
 func (pkg *Package) Equal(other *Package) bool {
@@ -82,7 +82,7 @@ type VerificationCode struct {
 // Package metadata.
 func (vc *VerificationCode) M() *Meta { return vc.Meta }
 
-// Checks if two VerificationCodes are equal. Ignores metadata. elements
+// Equal checks if two VerificationCodes are equal. Ignores metadata. elements
 // in the slice ExcludedFiles must be in the same order for this method to
 // return true.
 func (vc *VerificationCode) Equal(other *VerificationCode) bool {
@@ -109,10 +109,10 @@ type Checksum struct {
 	*Meta
 }
 
-// Compares two checksums, ignoring their metadatas.
+// Equal compares two checksums, ignoring their metadatas.
 func (c *Checksum) Equal(d *Checksum) bool {
 	return c == d || (c != nil && d != nil && c.Algo.Val == d.Algo.Val && c.Value.Val == d.Value.Val)
 }
 
-// Returns the checksum metadata.
+// M returns the checksum metadata.
 func (c *Checksum) M() *Meta { return c.Meta }

--- a/spdx/review.go
+++ b/spdx/review.go
@@ -8,10 +8,10 @@ type Review struct {
 	*Meta
 }
 
-// Returns the SPDX Review.
+// M returns the SPDX Review.
 func (r *Review) M() *Meta { return r.Meta }
 
-// Compares two Review pointers, ignoring any metadata.
+// Equal compares two Review pointers, ignoring any metadata.
 func (a *Review) Equal(b *Review) bool {
 	return a == b || (a != nil && b != nil &&
 		a.Reviewer.V() == b.Reviewer.V() && a.Date.V() == b.Date.V() && a.Comment.Val == b.Comment.Val)

--- a/spdx/validation.go
+++ b/spdx/validation.go
@@ -97,7 +97,7 @@ func NewValidator() *Validator {
 	}
 }
 
-// Return all the errors and warnings that this validator has.
+// Errors returns all the errors and warnings that this validator has.
 func (v *Validator) Errors() []*ValidationError { return v.errs }
 
 // Add a new error to this validator.
@@ -110,13 +110,13 @@ func (v *Validator) addWarn(msg string, m *Meta, args ...interface{}) {
 	v.add(NewVWarning(fmt.Sprintf(msg, args...), m))
 }
 
-// Return whether there are no errors and no warnings.
+// Ok returns whether there are no errors and no warnings.
 func (v *Validator) Ok() bool { return len(v.errs) == 0 }
 
-// Returns true if there are no warnings in this validator, false otherwise.
+// HasWarnings returns true if there are no warnings in this validator, false otherwise.
 func (v *Validator) HasWarnings() bool { return v.hasErrType(ValidWarning) }
 
-// Returns true if there are no errors in this validator, false otherwise.
+// HasErrors returns true if there are no errors in this validator, false otherwise.
 func (v *Validator) HasErrors() bool { return v.hasErrType(ValidError) }
 
 // Internal usage. Returns true if there are errors of type t (ValidationError.Type==t) in this validator, false otherwise.
@@ -141,7 +141,7 @@ func (v *Validator) add(err ...*ValidationError) {
 	v.errs = append(v.errs, err...)
 }
 
-// Adds an error to this validator if `val.V()` has more than one lines of text.
+// SingleLineErr adds an error to this validator if `val.V()` has more than one lines of text.
 func (v *Validator) SingleLineErr(val Value, property string) bool {
 	if strings.Index(val.V(), "\n") >= 0 {
 		v.addErr("%s must be a single line.", val.M(), property)
@@ -150,7 +150,7 @@ func (v *Validator) SingleLineErr(val Value, property string) bool {
 	return true
 }
 
-// Adds a warning to this validator if `val.V()` has more than one lines of text.
+// SingleLineWarn adds a warning to this validator if `val.V()` has more than one lines of text.
 // Returns `false` if there was a warning added, `true` otherwise.
 func (v *Validator) SingleLineWarn(val Value, property string) bool {
 	if strings.Index(val.V(), "\n") >= 0 {
@@ -160,7 +160,7 @@ func (v *Validator) SingleLineWarn(val Value, property string) bool {
 	return true
 }
 
-// Adds an error if `val.V()` is empty.
+// MandatoryText adds an error if `val.V()` is empty.
 //
 // NOASSERTION and NONE values are considered invalid if `noassert` and `none`, respectively are set to false.
 // These values are treated as valid (do not generate errors) if the arguments are set to true.
@@ -182,7 +182,7 @@ func (v *Validator) MandatoryText(val Value, noassert, none bool, property strin
 	return true
 }
 
-// Validates `*ValueDate` values. If `val.Time() == nil` this generates an error and returns `false`.
+// Date validates `*ValueDate` values. If `val.Time() == nil` this generates an error and returns `false`.
 // It returns `true` otherwise.
 func (v *Validator) Date(val *ValueDate) bool {
 	if val.Time() == nil {
@@ -192,7 +192,7 @@ func (v *Validator) Date(val *ValueDate) bool {
 	return true
 }
 
-// Validate URLs. URLs must have a scheme to be valid.
+// Url validates URLs. URLs must have a scheme to be valid.
 func (v *Validator) Url(val *ValueStr, noassert, none bool, property string) bool {
 	if (noassert && val.V() == NOASSERTION) || (none && val.V() == NONE) {
 		return true
@@ -210,7 +210,7 @@ func (v *Validator) Url(val *ValueStr, noassert, none bool, property string) boo
 	return true
 }
 
-// Validate a *Document. After validating doc, it checks whether all licence
+// Document validates a *Document. After validating doc, it checks whether all licence
 // references are in place (all "LicenceRef-" type licences used inside the
 // document and its nested elements are defined in doc.ExtractedLicences).
 //
@@ -290,7 +290,7 @@ func (v *Validator) Document(doc *Document) bool {
 	return v.HasErrors()
 }
 
-// Checks if all the licences referenced in the SPDX Document (and indexed by
+// LicReferences checks if all the licences referenced in the SPDX Document (and indexed by
 // the Validator) are used and defined.
 //
 // Licence References used but not defined generate errors.
@@ -315,7 +315,7 @@ func (v *Validator) LicReferences() bool {
 	return r
 }
 
-// Validate SpecVersion. Updates v.Major and v.Minor.
+// SpecVersion validates SpecVersion. Updates v.Major and v.Minor.
 //
 // Valid option: SPDX-M.m (M major version, m minor version)
 // Warning on: (any case "SPDX"): spdx-M.m, SPDXM.m, M.m
@@ -336,7 +336,7 @@ func (v *Validator) SpecVersion(val *ValueStr) bool {
 	return false
 }
 
-// Check if the SPDX version this validator has is currently supported by this
+// VersionSupported checks if the SPDX version this validator has is currently supported by this
 // library and adds an error if it is not.
 // Please keep SpecVersions updated in spdx/base.go.
 func (v *Validator) VersionSupported(m *Meta) bool {
@@ -350,7 +350,7 @@ func (v *Validator) VersionSupported(m *Meta) bool {
 	return false
 }
 
-// Validate Data Licence. The only valid value is "CC0-1.0".
+// DataLicence validates Data Licence. The only valid value is "CC0-1.0".
 // A warning is generated for non-uppercase "CC".
 func (v *Validator) DataLicence(val *ValueStr) bool {
 	if val.Val == "CC0-1.0" {
@@ -364,12 +364,12 @@ func (v *Validator) DataLicence(val *ValueStr) bool {
 	return false
 }
 
-// Validate DocumentCreator. It returns whether the checked value is valid or not.
+// DocumentCreator validates DocumentCreator. It returns whether the checked value is valid or not.
 func (v *Validator) DocumentCreator(val *ValueCreator) bool {
 	return v.Creator(val, false, false, "Document Creator", []string{"Tool", "Organization", "Person"}, 0)
 }
 
-// Validate *ValueCreator types.
+// Creator validates *ValueCreator types.
 //
 // The ValueCreator Syntax is: "What: Who (email)" where the "(email)" is optional.
 //
@@ -417,7 +417,7 @@ func (v *Validator) Creator(val *ValueCreator, noassert, none bool, property str
 	return true
 }
 
-// Validate a Review
+// Review validates a Review
 func (v *Validator) Review(rev *Review) bool {
 	if rev.Reviewer.val == "" && rev.Date.val == "" {
 		return true
@@ -426,7 +426,7 @@ func (v *Validator) Review(rev *Review) bool {
 	return v.Date(&rev.Date) && r
 }
 
-// Validate a Package.
+// Package validates a Package.
 //
 // Adds the following errors, if found:
 // - Package name is empty or on multiple lines.
@@ -495,7 +495,7 @@ func (v *Validator) Package(pkg *Package) bool {
 	return r
 }
 
-// Validate File.
+// File validates File.
 //
 // Adds the following errors, if found:
 // - Empty file name
@@ -601,7 +601,7 @@ func (v *Validator) File(f *File) bool {
 	return r
 }
 
-// Validate ArtifactOf.
+// ArtifactOf validates ArtifactOf.
 //
 // Adds an error if:
 // - The artifact is empty (nil pointer or empty values)
@@ -723,7 +723,7 @@ func (v *Validator) useLicence(id string, m *Meta) {
 	v.licUsed[id] = m
 }
 
-// Validates an AnyLicence object, treating NONE and NOASSERTION.
+// AnyLicenceOptionals validates an AnyLicence object, treating NONE and NOASSERTION.
 func (v *Validator) AnyLicenceOptionals(lic AnyLicence, allowSets, none, noassert bool, property string) bool {
 	t, ok := lic.(Licence)
 	if ok && ((none && t.V() == NONE) || (noassert && t.V() == NOASSERTION)) {
@@ -805,7 +805,7 @@ func (v *Validator) LicenceRefId(id string, meta *Meta, property string) bool {
 	return false
 }
 
-// Validate ExtractedLicence object
+// ExtractedLicence validates ExtractedLicence object
 //
 // Adds errors if:
 // - ID is not a valid Licence Reference format ("LicenseRef-...")

--- a/tag/api.go
+++ b/tag/api.go
@@ -17,13 +17,13 @@ var (
 // Set the Lexer.IgnoreMeta used by Build() function. Default is false.
 func IgnoreMeta(meta bool) { noMeta = meta }
 
-// Get the current option used by Lexer.IgnoreMeta used by Build().
+// GetIgnoreMeta gets the current option used by Lexer.IgnoreMeta used by Build().
 func GetIgnoreMeta() bool { return noMeta }
 
 // Set the Lexer.CaseSensitive option used by Build() function. Default is false.
 func CaseSensitive(ci bool) { caseSensitive = ci }
 
-// Get the current option for Lexer.IgnoreCase used by Build().
+// GetCaseSensitive gets the current option for Lexer.IgnoreCase used by Build().
 func GetCaseSensitive() bool { return caseSensitive }
 
 // Lex a io.Reader and Parse it to a *spdx.Document. If there is an error, it is

--- a/tag/lexer.go
+++ b/tag/lexer.go
@@ -121,7 +121,7 @@ func NewLexer(r io.Reader) *Lexer {
 	return lexer
 }
 
-// Get the current token (must be called after Lex()).
+// Token gets the current token (must be called after Lex()).
 // The returned *Token will be changed at the next call to Lex(). See Lex() for more.
 func (l *Lexer) Token() *Token {
 	return l.token
@@ -183,13 +183,13 @@ func (l *Lexer) Lex() bool {
 	return true
 }
 
-// Get the last error. If there is an error, it is either an I/O error returned initially by the associated io.Reader
+// Err gets the last error. If there is an error, it is either an I/O error returned initially by the associated io.Reader
 // or an error of type *ParseError.
 func (l *Lexer) Err() error {
 	return l.err
 }
 
-// Return the line of last token (end line). This property is available even when IgnoreMeta is set to true.
+// Line returns the line of last token (end line). This property is available even when IgnoreMeta is set to true.
 // Use Token.Meta properties Token.LineStart and Token.LineEnd when those are available.
 func (l *Lexer) Line() int {
 	return l.line

--- a/tag/properties.go
+++ b/tag/properties.go
@@ -71,14 +71,14 @@ func initProperties() {
 	}
 }
 
-// Checks whether the property is valid, case sensitive
+// IsValidProperty checks whether the property is valid, case sensitive
 func IsValidProperty(prop string) bool {
 	initProperties()
 	_, ok := properties[prop]
 	return ok
 }
 
-// Returns whether the given property is valid in a case-insensitive manner
+// IsValidPropertyInsensitive returns whether the given property is valid in a case-insensitive manner
 // along with the Correct Case for that property.
 func IsValidPropertyInsensitive(prop string) (bool, string) {
 	initProperties()

--- a/tag/writer.go
+++ b/tag/writer.go
@@ -87,7 +87,7 @@ func (f *Formatter) spaces(now string) {
 	}
 }
 
-// Read all tokens from a lexer and pretty-print them.
+// Lexer reads all tokens from a lexer and pretty-print them.
 func (f *Formatter) Lexer(lex lexer) error {
 	for lex.Lex() {
 		err := f.Token(lex.Token())
@@ -98,7 +98,7 @@ func (f *Formatter) Lexer(lex lexer) error {
 	return lex.Err()
 }
 
-// Write a Token.
+// Token writes a Token.
 func (f *Formatter) Token(tok *Token) error {
 	if tok == nil || (tok.Type == TokenPair && tok.Pair.Value == "") {
 		return nil
@@ -113,7 +113,7 @@ func (f *Formatter) Token(tok *Token) error {
 	}
 }
 
-// Write a comment (# comment).
+// Comment writes a comment (# comment).
 func (f *Formatter) Comment(comment string) error {
 	f.spaces(commentLastWritten)
 
@@ -127,7 +127,7 @@ func (f *Formatter) Comment(comment string) error {
 	return err
 }
 
-// Write a property (tag: value).
+// Property writes a property (tag: value).
 func (f *Formatter) Property(tag, value string) error {
 	if value == "" {
 		return nil
@@ -143,7 +143,7 @@ func (f *Formatter) Property(tag, value string) error {
 	return err
 }
 
-// Write a list of properties.
+// Properties writes a list of properties.
 func (f *Formatter) Properties(props []Pair) error {
 	for _, p := range props {
 		if err := f.Property(p.Key, p.Value); err != nil {
@@ -153,7 +153,7 @@ func (f *Formatter) Properties(props []Pair) error {
 	return nil
 }
 
-// Write a property with multiple values. The same tag is printed for each
+// PropertySlice writes a property with multiple values. The same tag is printed for each
 // non-empty value found in `values`.
 func (f *Formatter) PropertySlice(tag string, values []spdx.ValueStr) error {
 	for _, val := range values {
@@ -164,7 +164,7 @@ func (f *Formatter) PropertySlice(tag string, values []spdx.ValueStr) error {
 	return nil
 }
 
-// Write a ValueCreator slice. The same tag is printed for each non-empty value
+// CreatorSlice writes a ValueCreator slice. The same tag is printed for each non-empty value
 // found in `values`.
 func (f *Formatter) CreatorSlice(tag string, values []spdx.ValueCreator) error {
 	for _, val := range values {
@@ -175,7 +175,7 @@ func (f *Formatter) CreatorSlice(tag string, values []spdx.ValueCreator) error {
 	return nil
 }
 
-// Write a list of licences. The same tag is printed for each non-empty value
+// PropertyLicenceSlice writes a list of licences. The same tag is printed for each non-empty value
 // found in `values`.
 func (f *Formatter) PropertyLicenceSlice(tag string, values []spdx.AnyLicence) error {
 	for _, lic := range values {
@@ -186,7 +186,7 @@ func (f *Formatter) PropertyLicenceSlice(tag string, values []spdx.AnyLicence) e
 	return nil
 }
 
-// Write `doc` incuding all its nested elements.
+// Document writes `doc` incuding all its nested elements.
 func (f *Formatter) Document(doc *spdx.Document) error {
 	if doc == nil {
 		return nil
@@ -231,7 +231,7 @@ func (f *Formatter) Document(doc *spdx.Document) error {
 	return f.ExtractedLicences(doc.ExtractedLicences)
 }
 
-// Write `ci` the creation info part of a document.
+// CreationInfo writes `ci` the creation info part of a document.
 func (f *Formatter) CreationInfo(ci *spdx.CreationInfo) error {
 	if ci == nil {
 		return nil
@@ -248,7 +248,7 @@ func (f *Formatter) CreationInfo(ci *spdx.CreationInfo) error {
 	})
 }
 
-// Write all the Packages in pkgs.
+// Packages writes all the Packages in pkgs.
 func (f *Formatter) Packages(pkgs []*spdx.Package) error {
 	for _, pkg := range pkgs {
 		if err := f.Package(pkg); err != nil {
@@ -258,7 +258,7 @@ func (f *Formatter) Packages(pkgs []*spdx.Package) error {
 	return nil
 }
 
-// Write `pkg` and all its nested elements.
+// Package writes `pkg` and all its nested elements.
 func (f *Formatter) Package(pkg *spdx.Package) error {
 	if pkg == nil {
 		return nil
@@ -302,7 +302,7 @@ func (f *Formatter) Package(pkg *spdx.Package) error {
 	})
 }
 
-// Write all elements in `files`.
+// Files writes all elements in `files`.
 func (f *Formatter) Files(files []*spdx.File) error {
 	for _, file := range files {
 		if err := f.File(file); err != nil {
@@ -312,7 +312,7 @@ func (f *Formatter) Files(files []*spdx.File) error {
 	return nil
 }
 
-// Write `file` and all its nested elements.
+// File writes `file` and all its nested elements.
 func (f *Formatter) File(file *spdx.File) error {
 	if file == nil {
 		return nil
@@ -360,7 +360,7 @@ func (f *Formatter) File(file *spdx.File) error {
 	return nil
 }
 
-// Write all the reviews in `reviews`.
+// Reviews writes all the reviews in `reviews`.
 func (f *Formatter) Reviews(reviews []*spdx.Review) error {
 	for _, review := range reviews {
 		if err := f.Review(review); err != nil {
@@ -370,7 +370,7 @@ func (f *Formatter) Reviews(reviews []*spdx.Review) error {
 	return nil
 }
 
-// Write the *spdx.Review `rev`.
+// Review writes the *spdx.Review `rev`.
 func (f *Formatter) Review(review *spdx.Review) error {
 	if review == nil {
 		return nil
@@ -383,7 +383,7 @@ func (f *Formatter) Review(review *spdx.Review) error {
 	})
 }
 
-// Write all licences in `lics`.
+// ExtractedLicences writes all licences in `lics`.
 func (f *Formatter) ExtractedLicences(lics []*spdx.ExtractedLicence) error {
 	for _, lic := range lics {
 		if err := f.ExtractedLicence(lic); err != nil {
@@ -393,7 +393,7 @@ func (f *Formatter) ExtractedLicences(lics []*spdx.ExtractedLicence) error {
 	return nil
 }
 
-// Write the ExtractedLicence `lic`.
+// ExtractedLicence writes the ExtractedLicence `lic`.
 func (f *Formatter) ExtractedLicence(lic *spdx.ExtractedLicence) error {
 	if lic == nil {
 		return nil


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?